### PR TITLE
Fix address assembling

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Communication with ARES & Justice (Czech business registers).
 ## Installation
 
 ```sh
-composer require webnazakazku/ares
+composer require sunkaflek/ares
 ```
 
 ## Usage
@@ -18,7 +18,7 @@ composer require webnazakazku/ares
 <?php
 require __DIR__.'/vendor/autoload.php';
 
-use Webnazakazku\Ares;
+use Sunkaflek\Ares;
 
 $ares = new Ares();
 

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "autoload": {
         "psr-4": {
-            "sunkaflek\\": "src/"
+            "Sunkaflek\\": "src/"
         }
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,11 @@
         }
     ],
     "require": {
-        "php": ">=7.2.0",
+        "php": ">=5.5",
         "beberlei/assert": "^2.4|^3.0",
         "dfridrich/library": "^1.0",
         "fabpot/goutte": "^2.0|^3.0|^4.0",
-        "guzzlehttp/guzzle": "^6.5|^7.0"
+        "guzzlehttp/guzzle": "^6.0|^7.0"
     },
     "require-dev": {
         "symplify/coding-standard": "^8.3",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "webnazakazku/ares",
+    "name": "sunkaflek/ares",
     "type": "library",
     "description": "Communication with ARES (Czech business register)",
     "keywords": ["php", "ares"],
@@ -28,7 +28,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Webnazakazku\\": "src/"
+            "sunkaflek\\": "src/"
         }
     },
     "config": {

--- a/src/Ares.php
+++ b/src/Ares.php
@@ -151,7 +151,7 @@ class Ares
             throw new AresException('IČ firmy musí být zadáno.');
         }
 
-        $cachedFileName = $id . '_' . date($this->cacheStrategy) . '.php';
+        $cachedFileName = $id . '_' . date($this->cacheStrategy) . '.cache';
         $cachedFile = $this->cacheDir . '/bas_' . $cachedFileName;
         $cachedRawFile = $this->cacheDir . '/bas_raw_' . $cachedFileName;
 
@@ -314,7 +314,7 @@ class Ares
         // Sestaveni URL
         $url = $this->wrapUrl(sprintf(self::URL_RES, $id));
 
-        $cachedFileName = $id . '_' . date($this->cacheStrategy) . '.php';
+        $cachedFileName = $id . '_' . date($this->cacheStrategy) . '.cache';
         $cachedFile = $this->cacheDir . '/res_' . $cachedFileName;
         $cachedRawFile = $this->cacheDir . '/res_raw_' . $cachedFileName;
 
@@ -375,7 +375,7 @@ class Ares
         // Sestaveni URL
         $url = $this->wrapUrl(sprintf(self::URL_TAX, $id));
 
-        $cachedFileName = $id . '_' . date($this->cacheStrategy) . '.php';
+        $cachedFileName = $id . '_' . date($this->cacheStrategy) . '.cache';
         $cachedFile = $this->cacheDir . '/tax_' . $cachedFileName;
         $cachedRawFile = $this->cacheDir . '/tax_raw_' . $cachedFileName;
 
@@ -433,7 +433,7 @@ class Ares
             urlencode(Lib::stripDiacritics($city))
         ));
 
-        $cachedFileName = date($this->cacheStrategy) . '_' . md5($name . $city) . '.php';
+        $cachedFileName = date($this->cacheStrategy) . '_' . md5($name . $city) . '.cache';
         $cachedFile = $this->cacheDir . '/find_' . $cachedFileName;
         $cachedRawFile = $this->cacheDir . '/find_raw_' . $cachedFileName;
 

--- a/src/Ares.php
+++ b/src/Ares.php
@@ -9,6 +9,22 @@ use Sunkaflek\Ares\AresRecords;
 use Sunkaflek\Ares\TaxRecord;
 use InvalidArgumentException;
 
+if (!function_exists('str_starts_with')) {
+	function str_starts_with($haystack, $needle) {
+		return (string)$needle !== '' && strncmp($haystack, $needle, strlen($needle)) === 0;
+	}
+}
+
+if (!function_exists('str_ends_with')) {
+	function str_ends_with($haystack, $needle) {
+		return $needle !== '' && substr($haystack, -strlen($needle)) === (string)$needle;
+	}
+}
+if (!function_exists('str_contains')) {
+	function str_contains($haystack, $needle) {
+		return $needle !== '' && mb_strpos($haystack, $needle) !== false;
+	}
+}
 /**
  * Class Ares.
  *
@@ -17,7 +33,7 @@ use InvalidArgumentException;
 class Ares
 {
 
-    const URL_BAS = 'http://wwwinfo.mfcr.cz/cgi-bin/ares/darv_bas.cgi?ico=%s';
+    const URL_BAS = 'https://ares.gov.cz/ekonomicke-subjekty-v-be/rest/ekonomicke-subjekty/%s';
 
     const URL_RES = 'http://wwwinfo.mfcr.cz/cgi-bin/ares/darv_res.cgi?ICO=%s';
 
@@ -129,7 +145,6 @@ class Ares
      */
     public function findByIdentificationNumber($id)
     {
-        $id = Lib::toInteger($id);
         $this->ensureIdIsInteger($id);
 
         if (empty($id)) {
@@ -148,103 +163,119 @@ class Ares
         $url = $this->wrapUrl(sprintf(self::URL_BAS, $id));
 
         try {
-            $aresRequest = file_get_contents($url, null, stream_context_create($this->contextOptions));
+			$ch = curl_init($url);
+			curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
+
+			$aresRequest = curl_exec($ch);
+			$httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+
+			curl_close($ch);
+
+			if ($httpCode >= 400) {
+				if ($httpCode === 404) {
+					throw new AresException('IČ firmy nebylo nalezeno.');
+				}
+
+				try {
+					$aresResponse = json_decode($aresRequest, FALSE, 512, JSON_THROW_ON_ERROR);
+					throw new AresException(sprintf('Databáze ARES není dostupná. Zpráva: %s - %s - %s', $aresResponse->kod, $aresResponse->popis, $aresResponse->subKod));
+				} catch (AresException $e) {
+					throw $e;
+				} catch (\Exception $e) {
+					throw new AresException(sprintf('Databáze ARES není dostupná. Zpráva: %s', $e->getMessage()));
+				}
+			}
+
+            //$aresRequest = file_get_contents($url, false, stream_context_create($this->contextOptions));
             if ($this->debug) {
                 file_put_contents($cachedRawFile, $aresRequest);
             }
-            $aresResponse = simplexml_load_string($aresRequest);
 
+			$aresResponse = json_decode($aresRequest, FALSE, 512);
             if ($aresResponse) {
-                $ns = $aresResponse->getDocNamespaces();
-                $data = $aresResponse->children($ns['are']);
-                $elements = $data->children($ns['D'])->VBAS;
-
-                $ico = (int) $elements->ICO;
+                $ico = $aresResponse->ico ?: null;
                 if ($ico !== $id) {
                     throw new AresException('IČ firmy nebylo nalezeno.');
                 }
 
                 $record = new AresRecord();
 
-                $record->setCompanyId(strval($elements->ICO));
-                $record->setTaxId(strval($elements->DIC));
-
-                //prevent company names in quotes
-                if (substr(strval($elements->OF), 0, 1) === '"' AND substr(strval($elements->OF), -1) ==='"') {
-                    $record->setCompanyName(substr(strval($elements->OF),1,-1));
-                } else {
-                    $record->setCompanyName(strval($elements->OF));
-                }
+                $record->setCompanyId($ico);
+                $record->setTaxId($aresResponse->dic ?? '');
                 
-                if (strval($elements->AA->NU)) {
-                    $record->setStreet(strval($elements->AA->NU));
-                //Put town or part of town as street if there is no street to prevent just house number as street
-                } else if (strval($elements->AA->NCO)) {
-                    $record->setStreet(strval($elements->AA->NCO)); 
-                } else if (strval($elements->AA->N)) {
-                    $record->setStreet(strval($elements->AA->N)); 
+                $obchodniJmeno = $aresResponse->obchodniJmeno;
+                if (substr($obchodniJmeno, 0, 1) === '"' AND substr($obchodniJmeno, -1) ==='"') {
+                    $obchodniJmeno = substr($obchodniJmeno,1,-1);
                 }
-
-                if (strval($elements->AA->CO)) {
-                    $record->setStreetHouseNumber(strval($elements->AA->CD));
-                    $record->setStreetOrientationNumber(strval($elements->AA->CO));
-                } else if (strval($elements->AA->CD)){
-                    $record->setStreetHouseNumber(strval($elements->AA->CD));
-                } else {
-                    $record->setStreetHouseNumber(strval($elements->AA->CA));
-                }
-
-                //Prevents doubling town area (like "Praha-Libuš - Libuš" or "Brandýs nad Labem-Stará Boleslav - Brandýs nad Labem"
-                $townAlreadyContainsArea = false;
-                if (
-                    strval($elements->AA->N) === 'Praha' 
-                    AND !empty(strval($elements->AA->NCO)) 
-                    AND strpos(strval($elements->AA->NMC), strval($elements->AA->NCO)) !== false
-                   ) 
-                {
-                    $townAlreadyContainsArea = true;
-                } else if (
-                    !empty(strval($elements->AA->NCO)) 
-                    AND strpos(strval($elements->AA->N), strval($elements->AA->NCO)) !== false
-                ) 
-                {
-                    $townAlreadyContainsArea = true;
-                }
-
-                if (strval($elements->AA->N) === 'Praha') { //Praha
-
-                    //If Praha is not mentioned in NMC, which happens, albeit rarely. Whithout this the town result would look like " - Vinohrady"
-                    if (strpos(strval($elements->AA->NMC), 'Praha') === false) {
-                        $record->setTown(strval($elements->AA->N) . ' - ' . strval($elements->AA->NCO));
-                    } else {
-                        if (!$townAlreadyContainsArea) {
-                            $record->setTown(strval($elements->AA->NMC) . ' - ' . strval($elements->AA->NCO));
-                        } else {
-                            $record->setTown(strval($elements->AA->NMC));
-                        }
-                    }
                     
-                } elseif (
-                    !empty(strval($elements->AA->NCO)) 
-                    AND strval($elements->AA->NCO) !== strval($elements->AA->N) 
-                    AND !$townAlreadyContainsArea
-                    ) 
-                { //Ostrava
-                    //Prevents duplication in town like "České Budějovice - České Budějovice 3"
-                    $areaBeginsWithTown = false;
-                    if (substr(strval($elements->AA->NCO), 0, strlen(strval($elements->AA->N))) === strval($elements->AA->N)) {
-                        $areaBeginsWithTown = true;
-                    }
-                    if (!$areaBeginsWithTown) {
-                        $record->setTown(strval($elements->AA->N) . ' - ' . strval($elements->AA->NCO));
-                    } else {
-                        $record->setTown(strval($elements->AA->NCO));
-                    }
-                } else {
-                    $record->setTown(strval($elements->AA->N));
-                }
+				$record->setCompanyName($obchodniJmeno);
 
-                $record->setZip(strval($elements->AA->PSC));
+				$street = $aresResponse->sidlo->nazevUlice ?? '';
+				if ($street === '') {
+					$street = $aresResponse->sidlo->nazevCastiObce ?? '';
+				}
+
+				$record->setStreet($street);
+				$record->setStreetHouseNumber($aresResponse->sidlo->cisloDomovni ?? '');
+                
+                $cisloOrientacni = $aresResponse->sidlo->cisloOrientacni ?? '';
+                if (isset($aresResponse->sidlo->cisloOrientacniPismeno)) $cisloOrientacni .= $aresResponse->sidlo->cisloOrientacniPismeno;
+                
+				$record->setStreetOrientationNumber($cisloOrientacni);
+				$town = $aresResponse->sidlo->nazevObce ?? '';
+
+				if ($town === 'Praha') {
+					if (isset($aresResponse->sidlo->nazevMestskeCastiObvodu)) {
+						$town = $aresResponse->sidlo->nazevMestskeCastiObvodu;
+						if (str_contains($town, '-')) {
+							$town = $aresResponse->sidlo->nazevMestskehoObvodu ?? $town;
+						}
+
+						$townPart = $aresResponse->sidlo->nazevCastiObce ?? NULL;
+						if ($townPart !== NULL && $townPart !== $town) {
+							$town .= ' - ' . $townPart;
+						}
+					} else {
+						$town = $aresResponse->sidlo->nazevMestskehoObvodu ?? $town;
+					}
+				} else {
+					$townPart = $aresResponse->sidlo->nazevCastiObce ?? NULL;
+					if ($townPart !== NULL && $townPart !== $town) {
+						$townPartContainsTown = FALSE;
+						if (str_starts_with($townPart, $town)) {
+							$townPartContainsTown = TRUE;
+						}
+
+						if ($townPartContainsTown) {
+							$town = $townPart;
+						} else {
+							$town .= ' - ' . $townPart;
+						}
+					}
+				}
+
+				$record->setTown($town);
+				$record->setZip((string)($aresResponse->sidlo->psc ?? ''));
+
+				if (isset($aresResponse->sidlo->textovaAdresa) && $record->getZip() === '' && $record->getTown() === '' && trim($record->getStreet()) === '') {
+					$re = '/([a-zA-ZěščřžýáíéĚŠČŘŽÝÁÍÉ ]+), (.*), PSČ ([0-9 ]+), /mUu';
+					preg_match($re, $aresResponse->sidlo->textovaAdresa, $matches);
+
+					if ($matches !== []) {
+						$record->setStreet($matches[2]);
+						$record->setTown($matches[1]);
+						$record->setZip(str_replace(' ', '', $matches[3]));
+					} else {
+						$re = '/([0-9 ]+) ([a-zA-ZěščřžýáíéĚŠČŘŽÝÁÍÉ 0-9-]+), /mUu';
+						preg_match($re, $aresResponse->sidlo->textovaAdresa, $matches);
+
+						if ($matches !== []) {
+							$record->setStreet($matches[2]);
+							$record->setTown($matches[2]);
+							$record->setZip(str_replace(' ', '', $matches[1]));
+						}
+					}
+				}
             } else {
                 throw new AresException('Databáze ARES není dostupná.');
             }
@@ -454,7 +485,7 @@ class Ares
      */
     private function ensureIdIsInteger($id)
     {
-        if (!is_int($id)) {
+        if (!is_numeric($id)) {
             throw new InvalidArgumentException('IČ firmy musí být číslo.');
         }
     }

--- a/src/Ares.php
+++ b/src/Ares.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Webnazakazku;
+namespace Sunkaflek;
 
 use Defr\Lib;
-use Webnazakazku\Ares\AresException;
-use Webnazakazku\Ares\AresRecord;
-use Webnazakazku\Ares\AresRecords;
-use Webnazakazku\Ares\TaxRecord;
+use Sunkaflek\Ares\AresException;
+use Sunkaflek\Ares\AresRecord;
+use Sunkaflek\Ares\AresRecords;
+use Sunkaflek\Ares\TaxRecord;
 use InvalidArgumentException;
 
 /**

--- a/src/Ares.php
+++ b/src/Ares.php
@@ -181,6 +181,8 @@ class Ares
                 //Put town or part of town as street if there is no street to prevent just house number as street
                 } else if (strval($elements->AA->NCO)) {
                     $record->setStreet(strval($elements->AA->NCO)); 
+                } else if (strval($elements->AA->N)) {
+                    $record->setStreet(strval($elements->AA->N)); 
                 }
 
                 if (strval($elements->AA->CO)) {

--- a/src/Ares.php
+++ b/src/Ares.php
@@ -210,11 +210,18 @@ class Ares
                 }
 
                 if (strval($elements->AA->N) === 'Praha') { //Praha
-                    if (!$townAlreadyContainsArea) {
-                        $record->setTown(strval($elements->AA->NMC) . ' - ' . strval($elements->AA->NCO));
+
+                    //If Praha is not mentioned in NMC, which happens, albeit rarely. Whithout this the town result would look like " - Vinohrady"
+                    if (strpos(strval($elements->AA->NMC), 'Praha') === false) {
+                        $record->setTown(strval($elements->AA->N) . ' - ' . strval($elements->AA->NCO));
                     } else {
-                        $record->setTown(strval($elements->AA->NMC));
+                        if (!$townAlreadyContainsArea) {
+                            $record->setTown(strval($elements->AA->NMC) . ' - ' . strval($elements->AA->NCO));
+                        } else {
+                            $record->setTown(strval($elements->AA->NMC));
+                        }
                     }
+                    
                 } elseif (
                     !empty(strval($elements->AA->NCO)) 
                     AND strval($elements->AA->NCO) !== strval($elements->AA->N) 

--- a/src/Ares.php
+++ b/src/Ares.php
@@ -221,7 +221,16 @@ class Ares
                     AND !$townAlreadyContainsArea
                     ) 
                 { //Ostrava
-                    $record->setTown(strval($elements->AA->N) . ' - ' . strval($elements->AA->NCO));
+                    //Prevents duplication in town like "České Budějovice - České Budějovice 3"
+                    $areaBeginsWithTown = false;
+                    if (substr(strval($elements->AA->NCO), 0, strlen(strval($elements->AA->N))) === strval($elements->AA->N)) {
+                        $areaBeginsWithTown = true;
+                    }
+                    if (!$areaBeginsWithTown) {
+                        $record->setTown(strval($elements->AA->N) . ' - ' . strval($elements->AA->NCO));
+                    } else {
+                        $record->setTown(strval($elements->AA->NCO));
+                    }
                 } else {
                     $record->setTown(strval($elements->AA->N));
                 }

--- a/src/Ares/AresException.php
+++ b/src/Ares/AresException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Webnazakazku\Ares;
+namespace Sunkaflek\Ares;
 
 /**
  * Class AresException.

--- a/src/Ares/AresRecord.php
+++ b/src/Ares/AresRecord.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Webnazakazku\Ares;
+namespace Sunkaflek\Ares;
 
-use Webnazakazku\Justice;
-use Webnazakazku\ValueObject\Person;
+use Sunkaflek\Justice;
+use Sunkaflek\ValueObject\Person;
 use Goutte\Client as GouteClient;
 use GuzzleHttp\Client as GuzzleClient;
 

--- a/src/Ares/AresRecords.php
+++ b/src/Ares/AresRecords.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Webnazakazku\Ares;
+namespace Sunkaflek\Ares;
 
 use ArrayIterator;
 

--- a/src/Ares/TaxRecord.php
+++ b/src/Ares/TaxRecord.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Webnazakazku\Ares;
+namespace Sunkaflek\Ares;
 
 /**
  * Class TaxRecord.

--- a/src/Justice.php
+++ b/src/Justice.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Webnazakazku;
+namespace Sunkaflek;
 
 use Assert\Assertion;
-use Webnazakazku\Justice\JusticeRecord;
-use Webnazakazku\Justice\SubjectNotFoundException;
-use Webnazakazku\Parser\JusticeJednatelPersonParser;
-use Webnazakazku\Parser\JusticeSpolecnikPersonParser;
+use Sunkaflek\Justice\JusticeRecord;
+use Sunkaflek\Justice\SubjectNotFoundException;
+use Sunkaflek\Parser\JusticeJednatelPersonParser;
+use Sunkaflek\Parser\JusticeSpolecnikPersonParser;
 use Goutte\Client;
 use Symfony\Component\DomCrawler\Crawler;
 

--- a/src/Justice/JusticeRecord.php
+++ b/src/Justice/JusticeRecord.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Webnazakazku\Justice;
+namespace Sunkaflek\Justice;
 
-use Webnazakazku\ValueObject\Person;
+use Sunkaflek\ValueObject\Person;
 
 final class JusticeRecord
 {

--- a/src/Justice/SubjectNotFoundException.php
+++ b/src/Justice/SubjectNotFoundException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Webnazakazku\Justice;
+namespace Sunkaflek\Justice;
 
 use Exception;
 

--- a/src/Parser/DateTimeParser.php
+++ b/src/Parser/DateTimeParser.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Webnazakazku\Parser;
+namespace Sunkaflek\Parser;
 
 use DateTime;
 use DateTimeInterface;

--- a/src/Parser/Helper/StringHelper.php
+++ b/src/Parser/Helper/StringHelper.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Webnazakazku\Parser\Helper;
+namespace Sunkaflek\Parser\Helper;
 
 final class StringHelper
 {

--- a/src/Parser/JusticeJednatelPersonParser.php
+++ b/src/Parser/JusticeJednatelPersonParser.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Webnazakazku\Parser;
+namespace Sunkaflek\Parser;
 
-use Webnazakazku\Parser\Helper\StringHelper;
-use Webnazakazku\ValueObject\Person;
+use Sunkaflek\Parser\Helper\StringHelper;
+use Sunkaflek\ValueObject\Person;
 use Symfony\Component\DomCrawler\Crawler;
 
 final class JusticeJednatelPersonParser

--- a/src/Parser/JusticeSpolecnikPersonParser.php
+++ b/src/Parser/JusticeSpolecnikPersonParser.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Webnazakazku\Parser;
+namespace Sunkaflek\Parser;
 
-use Webnazakazku\Parser\Helper\StringHelper;
-use Webnazakazku\ValueObject\Person;
+use Sunkaflek\Parser\Helper\StringHelper;
+use Sunkaflek\ValueObject\Person;
 use Symfony\Component\DomCrawler\Crawler;
 
 final class JusticeSpolecnikPersonParser

--- a/src/ValueObject/Person.php
+++ b/src/ValueObject/Person.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Webnazakazku\ValueObject;
+namespace Sunkaflek\ValueObject;
 
 use DateTime;
 use DateTimeInterface;

--- a/tests/AresTest.php
+++ b/tests/AresTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests;
 
-use Webnazakazku\Ares;
+use Sunkaflek\Ares;
 use PHPUnit\Framework\TestCase;
 
 final class AresTest extends TestCase

--- a/tests/AresTest.php
+++ b/tests/AresTest.php
@@ -39,13 +39,13 @@ final class AresTest extends TestCase
 
     public function testFindByIdentificationNumberException()
     {
-        $this->expectException(\Webnazakazku\Ares\AresException::class);
+        $this->expectException(\Sunkaflek\Ares\AresException::class);
         $this->ares->findByIdentificationNumber('A1234');
     }
 
     public function testFindByEmptyStringException()
     {
-        $this->expectException(\Webnazakazku\Ares\AresException::class);
+        $this->expectException(\Sunkaflek\Ares\AresException::class);
         $this->ares->findByIdentificationNumber('');
     }
 
@@ -58,7 +58,7 @@ final class AresTest extends TestCase
 
     public function testFindByNameNonExistentName()
     {
-        $this->expectException(\Webnazakazku\Ares\AresException::class);
+        $this->expectException(\Sunkaflek\Ares\AresException::class);
         $this->expectExceptionMessage('Nic nebylo nalezeno.');
 
         $this->ares->findByName('some non-existent company name');

--- a/tests/JusticeTest.php
+++ b/tests/JusticeTest.php
@@ -26,7 +26,7 @@ final class JusticeTest extends TestCase
     public function testFindById()
     {
         $justiceRecord = $this->justice->findById('27791394');
-        $this->assertInstanceOf('Webnazakazku\Justice\JusticeRecord', $justiceRecord);
+        $this->assertInstanceOf('Sunkaflek\Justice\JusticeRecord', $justiceRecord);
 
         $people = $justiceRecord->getPeople();
         $this->assertCount(2, $people);

--- a/tests/JusticeTest.php
+++ b/tests/JusticeTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests;
 
-use Webnazakazku\Justice;
+use Sunkaflek\Justice;
 use Goutte\Client;
 use PHPUnit\Framework\TestCase;
 


### PR DESCRIPTION
I've made some fixes while repairing about 1000 addresses in a company DB, like de-duplicating town areas, eliminating quotes around company name and taking street number from another element if present. The resulting addresses seem more readable and consistent this way.